### PR TITLE
Use remoteServerProductUserId for Set/GetClientAddress

### DIFF
--- a/FishNet/Plugins/FishyEOS/FishyEOS.cs
+++ b/FishNet/Plugins/FishyEOS/FishyEOS.cs
@@ -325,11 +325,20 @@ namespace FishNet.Transporting.FishyEOSPlugin
         }
 
         /// <summary>
-        /// EOS Not Used
+        /// Sets which address the client will connect to.
         /// </summary>
+        /// <param name="address">Address client will connect to as ProductUserId.ToString(). For example lobby owner.</param>
         public override void SetClientAddress(string address)
         {
-            _ = address;
+            RemoteProductUserId = address;
+        }
+        
+        /// <summary>
+        /// Returns which address the client will connect to. Can be converted with ProductUserId.FromString().
+        /// </summary>
+        public override string GetClientAddress()
+        {
+            return RemoteProductUserId;
         }
 
         /// <summary>


### PR DESCRIPTION
I'd go step further and remove RemoteProductUserId, Set/GetClientAddress methods are basically the same. EOS transport for Mirror also uses them.

Currently using RemoteProductUserId requires code to cast transport to FishyEOS or reference it using additional SerializedField.